### PR TITLE
Extension of keycloak_generic_client_role_mapper resource to support realm-level roles association

### DIFF
--- a/example/roles.tf
+++ b/example/roles.tf
@@ -160,6 +160,44 @@ resource "keycloak_generic_client_role_mapper" "pet_app_pet_api_admin_role_mappi
   role_id   = "${keycloak_role.pet_api_admin.id}"
 }
 
+// Realm roles
+
+resource "keycloak_role" "realm_reader" {  
+  realm_id  = "${keycloak_realm.roles_example.id}"
+  name        = "realm_reader"
+  description = "Reader realm role"
+}
+
+resource "keycloak_role" "realm_writer" {
+  realm_id  = "${keycloak_realm.roles_example.id}"
+  name        = "realm_writer"
+  description = "Writer realm role"
+}
+
+resource "keycloak_role" "realm_admin" {
+  realm_id  = "${keycloak_realm.roles_example.id}"
+  name        = "realm_admin"
+  description = "Admin realm composite role"
+  composite_roles = [
+    "${keycloak_role.realm_reader.id}",
+    "${keycloak_role.realm_writer.id}"
+  ]
+}
+
+// Client scope for realm roles mapping 
+
+resource "keycloak_openid_client_scope" "petstore_api_access_scope" {
+  realm_id  = "${keycloak_realm.roles_example.id}"
+  name        = "petstore-api-access"
+  description = "Optional scope offering additional information for petstore api access"
+}
+
+resource "keycloak_generic_client_role_mapper" "petstore_api_access_scope_admin" {
+    realm_id  = "${keycloak_realm.roles_example.id}"
+    client_scope_id = "${keycloak_openid_client_scope.petstore_api_access_scope.id}"
+    role_id         = "${keycloak_role.realm_admin.id}"
+}
+
 // Users and groups
 
 resource "keycloak_group" "pet_api_base" {

--- a/keycloak/role_scope_mapping.go
+++ b/keycloak/role_scope_mapping.go
@@ -5,10 +5,19 @@ import (
 )
 
 func roleScopeMappingUrl(realmId, clientId string, clientScopeId string, role *Role) string {
+
 	if clientId != "" {
-		return fmt.Sprintf("/realms/%s/clients/%s/scope-mappings/clients/%s", realmId, clientId, role.ClientId)
-	} else {
+		if role.ClientRole {
+			return fmt.Sprintf("/realms/%s/clients/%s/scope-mappings/clients/%s", realmId, clientId, role.ClientId)
+		} else {
+			return fmt.Sprintf("/realms/%s/clients/%s/scope-mappings/realm", realmId, clientId)
+		}
+	}
+
+	if role.ClientRole {
 		return fmt.Sprintf("/realms/%s/client-scopes/%s/scope-mappings/clients/%s", realmId, clientScopeId, role.ClientId)
+	} else {
+		return fmt.Sprintf("/realms/%s/client-scopes/%s/scope-mappings/realm", realmId, clientScopeId)
 	}
 }
 


### PR DESCRIPTION
Extension of existing resource used to generically associate roles to client/client-scope with ability to include realm-level roles association.
with inclusion of:
- tests 
- examples
