### PR TITLE
Features/identity-provider-mapper-extra-config

### DIFF
--- a/example/main.tf
+++ b/example/main.tf
@@ -500,6 +500,11 @@ resource keycloak_attribute_importer_identity_provider_mapper oidc {
   claim_name              = "upn"
   identity_provider_alias = "${keycloak_oidc_identity_provider.oidc.alias}"
   user_attribute          = "email"
+  
+  #KC10 support
+  extra_config = {
+    syncMode = "INHERIT"    
+  }
 }
 
 resource keycloak_attribute_to_role_identity_provider_mapper oidc {
@@ -509,6 +514,11 @@ resource keycloak_attribute_to_role_identity_provider_mapper oidc {
   identity_provider_alias = "${keycloak_oidc_identity_provider.oidc.alias}"
   claim_value             = "value"
   role                    = "testRole"
+
+  #KC10 support
+  extra_config = {
+    syncMode = "INHERIT"    
+  }  
 }
 
 resource keycloak_user_template_importer_identity_provider_mapper oidc {
@@ -516,6 +526,11 @@ resource keycloak_user_template_importer_identity_provider_mapper oidc {
   name                    = "userTemplate"
   identity_provider_alias = "${keycloak_oidc_identity_provider.oidc.alias}"
   template                = "$${ALIAS}/$${CLAIM.upn}"
+
+  #KC10 support
+  extra_config = {
+    syncMode = "INHERIT"    
+  }  
 }
 
 resource keycloak_hardcoded_role_identity_provider_mapper oidc {
@@ -523,6 +538,11 @@ resource keycloak_hardcoded_role_identity_provider_mapper oidc {
   name                    = "hardcodedRole"
   identity_provider_alias = "${keycloak_oidc_identity_provider.oidc.alias}"
   role                    = "testrole"
+
+  #KC10 support
+  extra_config = {
+    syncMode = "INHERIT"    
+  }  
 }
 
 resource keycloak_hardcoded_attribute_identity_provider_mapper oidc {
@@ -532,6 +552,11 @@ resource keycloak_hardcoded_attribute_identity_provider_mapper oidc {
   attribute_name          = "attribute"
   attribute_value         = "value"
   user_session            = true
+
+  #KC10 support
+  extra_config = {
+    syncMode = "INHERIT"    
+  }  
 }
 
 resource keycloak_saml_identity_provider saml {
@@ -546,6 +571,11 @@ resource keycloak_attribute_importer_identity_provider_mapper saml {
   attribute_name          = "http://schemas.xmlsoap.org/ws/2005/05/identity/claims/emailaddress"
   identity_provider_alias = "${keycloak_saml_identity_provider.saml.alias}"
   user_attribute          = "email"
+
+  #KC10 support
+  extra_config = {
+    syncMode = "INHERIT"    
+  }
 }
 
 resource keycloak_attribute_to_role_identity_provider_mapper saml {
@@ -555,6 +585,11 @@ resource keycloak_attribute_to_role_identity_provider_mapper saml {
   identity_provider_alias = "${keycloak_saml_identity_provider.saml.alias}"
   attribute_value         = "value"
   role                    = "testRole"
+
+  #KC10 support
+  extra_config = {
+    syncMode = "INHERIT"    
+  }
 }
 
 resource keycloak_user_template_importer_identity_provider_mapper saml {
@@ -562,6 +597,11 @@ resource keycloak_user_template_importer_identity_provider_mapper saml {
   name                    = "userTemplate"
   identity_provider_alias = "${keycloak_saml_identity_provider.saml.alias}"
   template                = "$${ALIAS}/$${NAMEID}"
+
+  #KC10 support
+  extra_config = {
+    syncMode = "INHERIT"    
+  }  
 }
 
 resource keycloak_hardcoded_role_identity_provider_mapper saml {
@@ -569,6 +609,11 @@ resource keycloak_hardcoded_role_identity_provider_mapper saml {
   name                    = "hardcodedRole"
   identity_provider_alias = "${keycloak_saml_identity_provider.saml.alias}"
   role                    = "testrole"
+
+  #KC10 support
+  extra_config = {
+    syncMode = "INHERIT"    
+  }  
 }
 
 resource keycloak_hardcoded_attribute_identity_provider_mapper saml {
@@ -578,6 +623,11 @@ resource keycloak_hardcoded_attribute_identity_provider_mapper saml {
   attribute_name          = "attribute"
   attribute_value         = "value"
   user_session            = false
+  
+  #KC10 support
+  extra_config = {
+    syncMode = "INHERIT"    
+  }  
 }
 
 data "keycloak_openid_client" "broker" {

--- a/provider/generic_keycloak_identity_provider_mapper.go
+++ b/provider/generic_keycloak_identity_provider_mapper.go
@@ -2,9 +2,10 @@ package provider
 
 import (
 	"fmt"
+	"strings"
+
 	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
 	"github.com/mrparkers/terraform-provider-keycloak/keycloak"
-	"strings"
 )
 
 type identityProviderMapperDataGetterFunc func(data *schema.ResourceData, meta interface{}) (*keycloak.IdentityProviderMapper, error)
@@ -34,6 +35,10 @@ func resourceKeycloakIdentityProviderMapper() *schema.Resource {
 				Required:    true,
 				ForceNew:    true,
 				Description: "IDP Alias",
+			},
+			"extra_config": {
+				Type:     schema.TypeMap,
+				Optional: true,
 			},
 		},
 	}

--- a/provider/resource_keycloak_attribute_to_role_identity_provider_mapper.go
+++ b/provider/resource_keycloak_attribute_to_role_identity_provider_mapper.go
@@ -2,6 +2,7 @@ package provider
 
 import (
 	"fmt"
+
 	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
 	"github.com/mrparkers/terraform-provider-keycloak/keycloak"
 )
@@ -52,13 +53,20 @@ func resourceKeycloakAttributeToRoleIdentityProviderMapper() *schema.Resource {
 func getAttributeToRoleIdentityProviderMapperFromData(data *schema.ResourceData, meta interface{}) (*keycloak.IdentityProviderMapper, error) {
 	keycloakClient := meta.(*keycloak.KeycloakClient)
 	rec, _ := getIdentityProviderMapperFromData(data)
+	extraConfig := map[string]interface{}{}
+	if v, ok := data.GetOk("extra_config"); ok {
+		for key, value := range v.(map[string]interface{}) {
+			extraConfig[key] = value
+		}
+	}
 	identityProvider, err := keycloakClient.GetIdentityProvider(rec.Realm, rec.IdentityProviderAlias)
 	if err != nil {
 		return nil, handleNotFoundError(err, data)
 	}
 	rec.IdentityProviderMapper = fmt.Sprintf("%s-role-idp-mapper", identityProvider.ProviderId)
 	rec.Config = &keycloak.IdentityProviderMapperConfig{
-		Role: data.Get("role").(string),
+		Role:        data.Get("role").(string),
+		ExtraConfig: extraConfig,
 	}
 	if identityProvider.ProviderId == "saml" {
 		if attr, ok := data.GetOk("attribute_friendly_name"); ok {
@@ -95,5 +103,6 @@ func setAttributeToRoleIdentityProviderMapperData(data *schema.ResourceData, ide
 	data.Set("claim_name", identityProviderMapper.Config.Claim)
 	data.Set("claim_value", identityProviderMapper.Config.ClaimValue)
 	data.Set("attribute_friendly_name", identityProviderMapper.Config.AttributeFriendlyName)
+	data.Set("extra_config", identityProviderMapper.Config.ExtraConfig)
 	return nil
 }

--- a/provider/resource_keycloak_attribute_to_role_identity_provider_mapper_test.go
+++ b/provider/resource_keycloak_attribute_to_role_identity_provider_mapper_test.go
@@ -319,6 +319,7 @@ resource keycloak_attribute_to_role_identity_provider_mapper oidc {
 	extra_config 			= {
 		syncMode = "%s"
 	}
+}
 	`, realm, alias, name, role, claimName, claimValue, syncMode)
 }
 

--- a/provider/resource_keycloak_attribute_to_role_identity_provider_mapper_test.go
+++ b/provider/resource_keycloak_attribute_to_role_identity_provider_mapper_test.go
@@ -2,11 +2,12 @@ package provider
 
 import (
 	"fmt"
+	"testing"
+
 	"github.com/hashicorp/terraform-plugin-sdk/helper/acctest"
 	"github.com/hashicorp/terraform-plugin-sdk/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/terraform"
 	"github.com/mrparkers/terraform-provider-keycloak/keycloak"
-	"testing"
 )
 
 func TestAccKeycloakAttributeToRoleIdentityProviderMapper_basic(t *testing.T) {
@@ -24,6 +25,28 @@ func TestAccKeycloakAttributeToRoleIdentityProviderMapper_basic(t *testing.T) {
 		Steps: []resource.TestStep{
 			{
 				Config: testKeycloakAttributeToRoleIdentityProviderMapper_basic(realmName, alias, mapperName, role, claimName, claimValue),
+				Check:  testAccCheckKeycloakAttributeToRoleIdentityProviderMapperExists("keycloak_attribute_to_role_identity_provider_mapper.oidc"),
+			},
+		},
+	})
+}
+
+func TestAccKeycloakAttributeToRoleIdentityProviderMapper_withExtraConfig(t *testing.T) {
+	realmName := "terraform-" + acctest.RandString(10)
+	mapperName := "terraform-" + acctest.RandString(10)
+	alias := "terraform-" + acctest.RandString(10)
+	role := "terraform-" + acctest.RandString(10)
+	claimName := "terraform-" + acctest.RandString(10)
+	claimValue := "terraform-" + acctest.RandString(10)
+	syncMode := "terraform-" + acctest.RandString(10)
+
+	resource.Test(t, resource.TestCase{
+		Providers:    testAccProviders,
+		PreCheck:     func() { testAccPreCheck(t) },
+		CheckDestroy: testAccCheckKeycloakAttributeToRoleIdentityProviderMapperDestroy(),
+		Steps: []resource.TestStep{
+			{
+				Config: testKeycloakAttributeToRoleIdentityProviderMapper_withExtraConfig(realmName, alias, mapperName, role, claimName, claimValue, syncMode),
 				Check:  testAccCheckKeycloakAttributeToRoleIdentityProviderMapperExists("keycloak_attribute_to_role_identity_provider_mapper.oidc"),
 			},
 		},
@@ -59,6 +82,42 @@ func TestAccKeycloakAttributeToRoleIdentityProviderMapper_createAfterManualDestr
 					}
 				},
 				Config: testKeycloakAttributeToRoleIdentityProviderMapper_basic(realmName, alias, mapperName, role, claimName, claimValue),
+				Check:  testAccCheckKeycloakAttributeToRoleIdentityProviderMapperExists("keycloak_attribute_to_role_identity_provider_mapper.oidc"),
+			},
+		},
+	})
+}
+
+func TestAccKeycloakAttributeToRoleIdentityProviderMapper_withExtraConfig_createAfterManualDestroy(t *testing.T) {
+	var mapper = &keycloak.IdentityProviderMapper{}
+
+	realmName := "terraform-" + acctest.RandString(10)
+	mapperName := "terraform-" + acctest.RandString(10)
+	alias := "terraform-" + acctest.RandString(10)
+	role := "terraform-" + acctest.RandString(10)
+	claimName := "terraform-" + acctest.RandString(10)
+	claimValue := "terraform-" + acctest.RandString(10)
+	syncMode := "terraform-" + acctest.RandString(10)
+
+	resource.Test(t, resource.TestCase{
+		Providers:    testAccProviders,
+		PreCheck:     func() { testAccPreCheck(t) },
+		CheckDestroy: testAccCheckKeycloakAttributeToRoleIdentityProviderMapperDestroy(),
+		Steps: []resource.TestStep{
+			{
+				Config: testKeycloakAttributeToRoleIdentityProviderMapper_withExtraConfig(realmName, alias, mapperName, role, claimName, claimValue, syncMode),
+				Check:  testAccCheckKeycloakAttributeToRoleIdentityProviderMapperFetch("keycloak_attribute_to_role_identity_provider_mapper.oidc", mapper),
+			},
+			{
+				PreConfig: func() {
+					keycloakClient := testAccProvider.Meta().(*keycloak.KeycloakClient)
+
+					err := keycloakClient.DeleteIdentityProviderMapper(mapper.Realm, mapper.IdentityProviderAlias, mapper.Id)
+					if err != nil {
+						t.Fatal(err)
+					}
+				},
+				Config: testKeycloakAttributeToRoleIdentityProviderMapper_withExtraConfig(realmName, alias, mapperName, role, claimName, claimValue, syncMode),
 				Check:  testAccCheckKeycloakAttributeToRoleIdentityProviderMapperExists("keycloak_attribute_to_role_identity_provider_mapper.oidc"),
 			},
 		},
@@ -233,6 +292,34 @@ resource keycloak_attribute_to_role_identity_provider_mapper oidc {
 	claim_value             = "%s"
 }
 	`, realm, alias, name, role, claimName, claimValue)
+}
+
+func testKeycloakAttributeToRoleIdentityProviderMapper_withExtraConfig(realm, alias, name, role, claimName, claimValue, syncMode string) string {
+	return fmt.Sprintf(`
+resource "keycloak_realm" "realm" {
+	realm = "%s"
+}
+
+resource "keycloak_oidc_identity_provider" "oidc" {
+	realm             = "${keycloak_realm.realm.id}"
+	alias             = "%s"
+	authorization_url = "https://example.com/auth"
+	token_url         = "https://example.com/token"
+	client_id         = "example_id"
+	client_secret     = "example_token"
+}
+
+resource keycloak_attribute_to_role_identity_provider_mapper oidc {
+	realm                   = "${keycloak_realm.realm.id}"
+	name                    = "%s"
+	identity_provider_alias = "${keycloak_oidc_identity_provider.oidc.alias}"
+	role                    = "%s"
+	claim_name              = "%s"
+	claim_value             = "%s"
+	extra_config 			= {
+		syncMode = "%s"
+	}
+	`, realm, alias, name, role, claimName, claimValue, syncMode)
 }
 
 func testKeycloakAttributeToRoleIdentityProviderMapper_basicFromInterface(mapper *keycloak.IdentityProviderMapper) string {

--- a/provider/resource_keycloak_hardcoded_attribute_identity_provider_mapper.go
+++ b/provider/resource_keycloak_hardcoded_attribute_identity_provider_mapper.go
@@ -2,6 +2,7 @@ package provider
 
 import (
 	"fmt"
+
 	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
 	"github.com/mrparkers/terraform-provider-keycloak/keycloak"
 )
@@ -35,10 +36,17 @@ func resourceKeycloakHardcodedAttributeIdentityProviderMapper() *schema.Resource
 
 func getHardcodedAttributeIdentityProviderMapperFromData(data *schema.ResourceData, _ interface{}) (*keycloak.IdentityProviderMapper, error) {
 	rec, _ := getIdentityProviderMapperFromData(data)
+	extraConfig := map[string]interface{}{}
+	if v, ok := data.GetOk("extra_config"); ok {
+		for key, value := range v.(map[string]interface{}) {
+			extraConfig[key] = value
+		}
+	}
 	rec.IdentityProviderMapper = getHardcodedAttributeIdentityProviderMapperType(data.Get("user_session").(bool))
 	rec.Config = &keycloak.IdentityProviderMapperConfig{
 		HardcodedAttribute: data.Get("attribute_name").(string),
 		AttributeValue:     data.Get("attribute_value").(string),
+		ExtraConfig:        extraConfig,
 	}
 	return rec, nil
 }
@@ -47,6 +55,7 @@ func setHardcodedAttributeIdentityProviderMapperData(data *schema.ResourceData, 
 	setIdentityProviderMapperData(data, identityProviderMapper)
 	data.Set("attribute_name", identityProviderMapper.Config.HardcodedAttribute)
 	data.Set("attribute_value", identityProviderMapper.Config.AttributeValue)
+	data.Set("extra_config", identityProviderMapper.Config.ExtraConfig)
 	mapperType, err := getUserSessionFromHardcodedAttributeIdentityProviderMapperType(identityProviderMapper.IdentityProviderMapper)
 	if err != nil {
 		return err

--- a/provider/resource_keycloak_hardcoded_role_identity_provider_mapper.go
+++ b/provider/resource_keycloak_hardcoded_role_identity_provider_mapper.go
@@ -23,9 +23,16 @@ func resourceKeycloakHardcodedRoleIdentityProviderMapper() *schema.Resource {
 
 func getHardcodedRoleIdentityProviderMapperFromData(data *schema.ResourceData, _ interface{}) (*keycloak.IdentityProviderMapper, error) {
 	rec, _ := getIdentityProviderMapperFromData(data)
+	extraConfig := map[string]interface{}{}
+	if v, ok := data.GetOk("extra_config"); ok {
+		for key, value := range v.(map[string]interface{}) {
+			extraConfig[key] = value
+		}
+	}
 	rec.IdentityProviderMapper = "oidc-hardcoded-role-idp-mapper"
 	rec.Config = &keycloak.IdentityProviderMapperConfig{
-		Role: data.Get("role").(string),
+		Role:        data.Get("role").(string),
+		ExtraConfig: extraConfig,
 	}
 	return rec, nil
 }
@@ -33,5 +40,6 @@ func getHardcodedRoleIdentityProviderMapperFromData(data *schema.ResourceData, _
 func setHardcodedRoleIdentityProviderMapperData(data *schema.ResourceData, identityProviderMapper *keycloak.IdentityProviderMapper) error {
 	setIdentityProviderMapperData(data, identityProviderMapper)
 	data.Set("role", identityProviderMapper.Config.Role)
+	data.Set("extra_config", identityProviderMapper.Config.ExtraConfig)
 	return nil
 }

--- a/provider/resource_keycloak_user_template_importer_identity_provider_mapper.go
+++ b/provider/resource_keycloak_user_template_importer_identity_provider_mapper.go
@@ -2,6 +2,7 @@ package provider
 
 import (
 	"fmt"
+
 	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
 	"github.com/mrparkers/terraform-provider-keycloak/keycloak"
 )
@@ -25,13 +26,20 @@ func resourceKeycloakUserTemplateImporterIdentityProviderMapper() *schema.Resour
 func getUserTemplateImporterIdentityProviderMapperFromData(data *schema.ResourceData, meta interface{}) (*keycloak.IdentityProviderMapper, error) {
 	keycloakClient := meta.(*keycloak.KeycloakClient)
 	rec, _ := getIdentityProviderMapperFromData(data)
+	extraConfig := map[string]interface{}{}
+	if v, ok := data.GetOk("extra_config"); ok {
+		for key, value := range v.(map[string]interface{}) {
+			extraConfig[key] = value
+		}
+	}
 	identityProvider, err := keycloakClient.GetIdentityProvider(rec.Realm, rec.IdentityProviderAlias)
 	if err != nil {
 		return nil, handleNotFoundError(err, data)
 	}
 	rec.IdentityProviderMapper = fmt.Sprintf("%s-username-idp-mapper", identityProvider.ProviderId)
 	rec.Config = &keycloak.IdentityProviderMapperConfig{
-		Template: data.Get("template").(string),
+		Template:    data.Get("template").(string),
+		ExtraConfig: extraConfig,
 	}
 	return rec, nil
 }
@@ -39,5 +47,6 @@ func getUserTemplateImporterIdentityProviderMapperFromData(data *schema.Resource
 func setUserTemplateImporterIdentityProviderMapperData(data *schema.ResourceData, identityProviderMapper *keycloak.IdentityProviderMapper) error {
 	setIdentityProviderMapperData(data, identityProviderMapper)
 	data.Set("template", identityProviderMapper.Config.Template)
+	data.Set("extra_config", identityProviderMapper.Config.ExtraConfig)
 	return nil
 }

--- a/provider/resource_keycloak_user_template_importer_identity_provider_mapper_test.go
+++ b/provider/resource_keycloak_user_template_importer_identity_provider_mapper_test.go
@@ -2,11 +2,12 @@ package provider
 
 import (
 	"fmt"
+	"testing"
+
 	"github.com/hashicorp/terraform-plugin-sdk/helper/acctest"
 	"github.com/hashicorp/terraform-plugin-sdk/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/terraform"
 	"github.com/mrparkers/terraform-provider-keycloak/keycloak"
-	"testing"
 )
 
 func TestAccKeycloakUserTemplateIdentityProviderMapper_basic(t *testing.T) {
@@ -28,6 +29,26 @@ func TestAccKeycloakUserTemplateIdentityProviderMapper_basic(t *testing.T) {
 	})
 }
 
+func TestAccKeycloakUserTemplateIdentityProviderMapper_withExtraConfig(t *testing.T) {
+	realmName := "terraform-" + acctest.RandString(10)
+	mapperName := "terraform-" + acctest.RandString(10)
+	alias := "terraform-" + acctest.RandString(10)
+	template := "terraform-" + acctest.RandString(10)
+	syncMode := "terraform-" + acctest.RandString(10)
+
+	resource.Test(t, resource.TestCase{
+		Providers:    testAccProviders,
+		PreCheck:     func() { testAccPreCheck(t) },
+		CheckDestroy: testAccCheckKeycloakUserTemplateIdentityProviderMapperDestroy(),
+		Steps: []resource.TestStep{
+			{
+				Config: testKeycloakUserTemplateIdentityProviderMapper_withExtraConfig(realmName, alias, mapperName, template, syncMode),
+				Check:  testAccCheckKeycloakUserTemplateIdentityProviderMapperExists("keycloak_user_template_importer_identity_provider_mapper.oidc"),
+			},
+		},
+	})
+}
+
 func TestAccKeycloakUserTemplateIdentityProviderMapper_createAfterManualDestroy(t *testing.T) {
 	var mapper = &keycloak.IdentityProviderMapper{}
 
@@ -43,6 +64,40 @@ func TestAccKeycloakUserTemplateIdentityProviderMapper_createAfterManualDestroy(
 		Steps: []resource.TestStep{
 			{
 				Config: testKeycloakUserTemplateIdentityProviderMapper_basic(realmName, alias, mapperName, template),
+				Check:  testAccCheckKeycloakUserTemplateIdentityProviderMapperFetch("keycloak_user_template_importer_identity_provider_mapper.oidc", mapper),
+			},
+			{
+				PreConfig: func() {
+					keycloakClient := testAccProvider.Meta().(*keycloak.KeycloakClient)
+
+					err := keycloakClient.DeleteIdentityProviderMapper(mapper.Realm, mapper.IdentityProviderAlias, mapper.Id)
+					if err != nil {
+						t.Fatal(err)
+					}
+				},
+				Config: testKeycloakUserTemplateIdentityProviderMapper_basic(realmName, alias, mapperName, template),
+				Check:  testAccCheckKeycloakUserTemplateIdentityProviderMapperExists("keycloak_user_template_importer_identity_provider_mapper.oidc"),
+			},
+		},
+	})
+}
+
+func TestAccKeycloakUserTemplateIdentityProviderMapper_withExtraConfig_createAfterManualDestroy(t *testing.T) {
+	var mapper = &keycloak.IdentityProviderMapper{}
+
+	realmName := "terraform-" + acctest.RandString(10)
+	mapperName := "terraform-" + acctest.RandString(10)
+	alias := "terraform-" + acctest.RandString(10)
+	template := "terraform-" + acctest.RandString(10)
+	syncMode := "terraform-" + acctest.RandString(10)
+
+	resource.Test(t, resource.TestCase{
+		Providers:    testAccProviders,
+		PreCheck:     func() { testAccPreCheck(t) },
+		CheckDestroy: testAccCheckKeycloakUserTemplateIdentityProviderMapperDestroy(),
+		Steps: []resource.TestStep{
+			{
+				Config: testKeycloakUserTemplateIdentityProviderMapper_withExtraConfig(realmName, alias, mapperName, template, syncMode),
 				Check:  testAccCheckKeycloakUserTemplateIdentityProviderMapperFetch("keycloak_user_template_importer_identity_provider_mapper.oidc", mapper),
 			},
 			{
@@ -221,6 +276,33 @@ resource keycloak_user_template_importer_identity_provider_mapper oidc {
 	template                = "%s"
 }
 	`, realm, alias, name, template)
+}
+
+func testKeycloakUserTemplateIdentityProviderMapper_withExtraConfig(realm, alias, name, template, syncMode string) string {
+	return fmt.Sprintf(`
+resource "keycloak_realm" "realm" {
+	realm = "%s"
+}
+
+resource "keycloak_oidc_identity_provider" "oidc" {
+	realm             = "${keycloak_realm.realm.id}"
+	alias             = "%s"
+	authorization_url = "https://example.com/auth"
+	token_url         = "https://example.com/token"
+	client_id         = "example_id"
+	client_secret     = "example_token"
+}
+
+resource keycloak_user_template_importer_identity_provider_mapper oidc {
+	realm                   = "${keycloak_realm.realm.id}"
+	name                    = "%s"
+	identity_provider_alias = "${keycloak_oidc_identity_provider.oidc.alias}"
+	template                = "%s"
+	extra_config 			= {
+		syncMode = "%s"
+	}
+}
+	`, realm, alias, name, template, syncMode)
 }
 
 func testKeycloakUserTemplateIdentityProviderMapper_basicFromInterface(mapper *keycloak.IdentityProviderMapper) string {


### PR DESCRIPTION
KC10 introduced Identity Brokering Sync Mode with mandatory 'Sync Mode Override' field in all IDP mappers. This is the extension of the provider to support this in the form of an added "extra_config" optional field which can take any values and maps them in IDP Mappers Configuration:

example of usage against KC10:
_resource keycloak_hardcoded_role_identity_provider_mapper oidc {
  realm                   = "realm"
  name                    = "hardcodedRole"
  identity_provider_alias = "${keycloak_oidc_identity_provider.oidc.alias}"
  role                    = "testrole"
  extra_config = {
    syncMode = "FORCE" 
  }  
}



